### PR TITLE
Use correct separation character for POST body

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -111,7 +111,7 @@ class Request
                 $requestHeaders,
                 ['Content-Type' => 'application/x-www-form-urlencoded']
             ),
-            \http_build_query($postData, '&')
+            \http_build_query($postData, '', '&')
         );
     }
 


### PR DESCRIPTION
The second parameter is numeric prefix. The third is separator, it comes from php.ini but typically it's & so this still works fine. But it's better to be explicit.